### PR TITLE
Don’t hide real fields when providing synthetic values

### DIFF
--- a/jaitype.py
+++ b/jaitype.py
@@ -42,9 +42,6 @@ def Array( valobj: lldb.SBValue, internal_dict, options ):
 def ResizableArray( valobj: lldb.SBValue, internal_dict, options ):
   raw: lldb.SBValue = valobj.GetNonSyntheticValue()
   data = raw.GetChildMemberWithName( 'data' ).GetValueAsSigned()
-  if data == 0:
-    return ( "Array(uninitialised)" )
-
   return ( "Array(count="
            + str( raw.GetChildMemberWithName( 'count' ).GetValueAsSigned() )
            + ",allocated="
@@ -53,8 +50,9 @@ def ResizableArray( valobj: lldb.SBValue, internal_dict, options ):
 
 
 class ArrayChildrenProvider:
-  def __init__( self, valobj: lldb.SBValue, internal_dict ) :
+  def __init__( self, valobj: lldb.SBValue, internal_dict ):
     self.val = valobj
+    self.native = ["count", "data"]
 
   def update( self ):
     self.count = self.val.GetChildMemberWithName( 'count' ).GetValueAsSigned()
@@ -67,16 +65,29 @@ class ArrayChildrenProvider:
   def has_children( self ):
     return True
 
-  def num_children( self ):
-    return self.count
+  def num_children(self):
+    return len(self.native) + self.count;
 
-  def get_child_at_index( self, index ):
-    return self.data.CreateChildAtOffset( str( index ),
+  def get_child_index(self, name):
+    try:
+      return self.native.index(name)
+    except ValueError:
+      return len(self.native) + int( name )
+
+  def get_child_at_index(self, child_index):
+    if child_index < len(self.native):
+      return self.val.GetChildMemberWithName(self.native[child_index])
+      
+    index = child_index - len(self.native);
+    return self.data.CreateChildAtOffset( '[' + str(index) + ']',
                                           self.data_size * index,
                                           self.data_type )
 
-  def get_child_index( self, name ):
-    return int( name )
+
+class ResizableArrayChildrenProvider(ArrayChildrenProvider):
+  def __init__( self, valobj: lldb.SBValue, internal_dict):
+    ArrayChildrenProvider.__init__(self, valobj, internal_dict)
+    self.native = ["count", "data", "allocated", "allocator"]
 
 
 def __lldb_init_module( debugger: lldb.SBDebugger, dict ):
@@ -84,56 +95,10 @@ def __lldb_init_module( debugger: lldb.SBDebugger, dict ):
     debugpy.listen( 5432 )
     debugpy.wait_for_client()
 
-  if USE_CMDS:
-    C = debugger.HandleCommand
-    C( "type summary add -w Jai string -F jaitype.String" )
-    C( r"type summary add -e -w Jai -x '\[\] .*' -F jaitype.Array" )
-    C( r"type summary add -e -w Jai -x '\[\.\.\] .*' -F jaitype.ResizableArray" )
-    C( r"type synthetic add -w Jai -x '\[\] .*' -l jaitype.ArrayChildrenProvider" )
-    C( r"type synthetic add -w Jai -x '\[\.\.\] .*' -l jaitype.ArrayChildrenProvider" )
-    C( 'type category enable Jai' )
-  else:
-    # I can't work out how to specify the equivalent of "-e" here (or stricly
-    # the opposite, as the default appears to be to show all chilren, and
-    # _don't_ want to for string)
-    # There seem to be conflicting and overlapping flags in the lldb code:
-    #  eTypeOptionShowOneLiner, eTypeOptionHideChildren, etc.
-    # These all set flags on the various formatters (it's get/set methods all
-    # the way down), but i can't see them exposed in python. There's an options
-    # field on SBTypeSummary.CreateWithFunctionName, but i couldn't find a way
-    # to make it work)
-    #
-    # Anyway it works with the command line, which sets the defaults like this:
-    #
-    # m_flags.Clear().SetCascades().SetDontShowChildren().SetDontShowValue(false);
-    # m_flags.SetShowMembersOneLiner(false)
-    #     .SetSkipPointers(false)
-    #     .SetSkipReferences(false)
-    #     .SetHideItemNames(false);
-
-    cat: lldb.SBTypeCategory = debugger.CreateCategory( "Jai" )
-
-    string = lldb.SBTypeNameSpecifier( "string" )
-    cat.AddTypeSummary( string,
-                        lldb.SBTypeSummary.CreateWithFunctionName(
-                          'jaitype.String', ) )
-
-    array = lldb.SBTypeNameSpecifier( r'\[\] .*', True )
-    cat.AddTypeSummary(
-      array,
-      lldb.SBTypeSummary.CreateWithFunctionName( 'jaitype.Array' ) )
-    cat.AddTypeSynthetic(
-      array,
-      lldb.SBTypeSynthetic.CreateWithClassName(
-        'jaitype.ArrayChildrenProvider' ) )
-
-    rarray = lldb.SBTypeNameSpecifier( r'\[\.\.\] .*', True )
-    cat.AddTypeSummary(
-      rarray,
-      lldb.SBTypeSummary.CreateWithFunctionName( 'jaitype.ResizableArray' ) )
-    cat.AddTypeSynthetic(
-      rarray,
-      lldb.SBTypeSynthetic.CreateWithClassName(
-        'jaitype.ArrayChildrenProvider' ) )
-
-    cat.SetEnabled( True )
+  C = debugger.HandleCommand
+  C(  "type summary add    -w Jai string -F jaitype.String" )
+  C( r"type summary add -e -w Jai -x '\[\] .*'     -F jaitype.Array" )
+  C( r"type summary add -e -w Jai -x '\[\.\.\] .*' -F jaitype.ResizableArray" )
+  C( r"type synthetic add  -w Jai -x '\[\] .*'     -l jaitype.ArrayChildrenProvider" )
+  C( r"type synthetic add  -w Jai -x '\[\.\.\] .*' -l jaitype.ResizableArrayChildrenProvider" )
+  C(  'type category enable Jai' )


### PR DESCRIPTION
This change allows you to see the real fields (count, data, …) , not just the synthetic values.

I’ve also removed the disabled and stale code in `__lldb_init_module`